### PR TITLE
Move javascript tag from HEAD to the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ rules
 ### <a href="#jsonrails"></a>2.1. JS on Rails
 
 * [use callbacks](https://gist.github.com/3019231) instead of low-level `$.ajax` when possible
+* [move javascript tags](https://github.com/rails/rails/pull/7888) from `HEAD` to the bottom
 
 ## <a href="#rails"></a>3. Rails
 


### PR DESCRIPTION
I can agree that this rule as default could bring too many problems
for the beginners, but we should apply it always just from the beginning.
