### PR TITLE
Link rules to pull request issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ The Monterail's Rules
 
 ## <a href="#javascript"></a>2. JavaScript
 
-* "classes are for designers", so don't scope with `ids` and `classes` in js. JavaScript developers should use [data-* attributes](http://roytomeij.com/2012/dont-use-class-names-to-find-HTML-elements-with-JS.html), [js-* prefix for classes](http://coderwall.com/p/qktuzw) or [role attribute](https://github.com/kossnocorp/role)
+* "classes are for designers", so don't scope with `ids` and `classes` in js. JavaScript developers should use [data-* attributes](http://roytomeij.com/2012/dont-use-class-names-to-find-HTML-elements-with-JS.html), [js-* prefix for classes](http://coderwall.com/p/qktuzw) or [role attribute](https://github.com/kossnocorp/role) (go to [discussion](https://github.com/monterail/rules/pull/4))
 
 ### <a href="#jsonrails"></a>2.1. JS on Rails
 
 * [use callbacks](https://gist.github.com/3019231) instead of low-level `$.ajax` when possible
-* [move javascript tags](https://github.com/rails/rails/pull/7888) from `HEAD` to the bottom
+* [move javascript tags](https://github.com/rails/rails/pull/7888) from `HEAD` to the bottom (go to [discussion](https://github.com/monterail/rules/pull/2))
 
 ## <a href="#rails"></a>3. Rails
 
-* add [miniprofiler](http://railscasts.com/episodes/368-miniprofiler) to the `Gemfile` when using `RDBMS`
+* add [miniprofiler](http://railscasts.com/episodes/368-miniprofiler) to the `Gemfile` when using `RDBMS` (go to [discussion](https://github.com/monterail/rules/pull/3))
 
 ## <a href="#ruby"></a>4. Ruby
 


### PR DESCRIPTION
Brief, oneline rules are not always obvious. Also, in the feature, some
of the rules can become out-of-date or someone new in the team can disagree
with them. It would be a good practice to always add a link to the relative
issue next to the rule.

Inspired by http://betterspecs.org/
