### PR TITLE
Add convention for naming jQuery objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Follow the rules described in our [Git flow](GIT.md)
 ## JavaScript
 
 * "classes are for designers", so don't scope with `ids` and `classes` in js. JavaScript developers should use [data-* attributes](http://roytomeij.com/2012/dont-use-class-names-to-find-HTML-elements-with-JS.html), [js-* prefix for classes](http://coderwall.com/p/qktuzw) or [role attribute](https://github.com/kossnocorp/role) (go to [discussion](https://github.com/monterail/rules/pull/4))
+* prefix jQuery objects with `$` sign unless you are working with [angular project](http://angularjs.org/) (go to [discussion](https://github.com/monterail/rules/pull/10))
 
 ### JS on Rails
 


### PR DESCRIPTION
In my experience it is really usefull to prefix any jQuery object with `$`
sign - at first sight you just know what kind of object it is and what
you can expect from it.

Another profit is that convention helpfully distinct between jQuery and
DOM objects. E.g. [$.fn.each](http://api.jquery.com/each/) passes to the callback `index` and `Element`
which is simply a DOM object, not jQuery object which leads to confusion
to the novices who expects methods like `#html` or `#attr` etc. Even
more experienced developer could not know what kind of object he can
expect in a new codebase.
