### PR TITLE
Add testing stack to useful gems

### DIFF
--- a/rails/GEMS.md
+++ b/rails/GEMS.md
@@ -32,3 +32,12 @@ be treated as a "standard", please add it below.
 * [carrierwave](https://github.com/jnicklas/carrierwave) - file uploads
 * [friendly_id](https://github.com/norman/friendly_id) - slug generation
 * [rails_config](https://github.com/railsjedi/rails_config) - miscallanous settings for different stages
+
+## Testing
+
+* [capybara](https://github.com/jnicklas/capybara) - webrat replacement
+* [database_cleaner](https://github.com/bmabey/database_cleaner) - ensure a clean state during tests
+* [factory_girl](https://github.com/thoughtbot/factory_girl) - fixtures replacement
+* [factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails) - factory girl integration for rails
+* [rspec](https://github.com/rspec/rspec) - testing framework
+* [rspec-rails](https://github.com/rspec/rspec-rails) - rspec integration for rails


### PR DESCRIPTION
I've created a basic stack for testing, which I think most of us are using (almost) always.
- capybara
- database_cleaner
- factory_girl
- rspec

I'd like to give a try to minitest instead rspec, but let's stick to what we know already.

Any other proposals? Cucumber (let's flame begin again!)? Jasmine? [Konacha](https://github.com/jfirebaugh/konacha)? Or should I remove something from the basic list?
