### PR TITLE
Squash commits from feature branches before making a merge.

### DIFF
--- a/GIT.md
+++ b/GIT.md
@@ -23,7 +23,8 @@ On the other hand if you want to fetch others work from remote server use:
     $ git fetch origin
     $ git checkout -b feature/my-new-tiny-feature origin/feature/my-new-tiny-feature
 
-When the work is finished merge it into `dev` branch:
+
+When the work is finished [squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html) into single one and merge it into `dev` branch:
 
     in ~/workspace/project
     $ git checkout dev


### PR DESCRIPTION
We should always squash commits from a feature branch before merging
into dev(elop) branch. You will gain cleaner history and it would be
easier to revert if you need to give up the change.

Do it even if the feature branch is not local, but you are collaborating
with it.

Don't do it if branch is neither a "feature branch" nor "hotfix branch".
