### PR TITLE
Change HTTParty to Typhoeus

### DIFF
--- a/rails/GEMS.md
+++ b/rails/GEMS.md
@@ -6,7 +6,7 @@ be treated as a "standard", please add it below.
 
 ## API
 
-* [httparty](https://github.com/jnunemaker/httparty) - easy way to wrap http responses
+* [typhoeus](https://github.com/typhoeus/typhoeus) - runs HTTP requests while cleanly encapsulating handling logic
 * [roar](https://github.com/apotonick/roar) - very flexible way to create JSON representation of resources
 * [roar-rails](https://github.com/apotonick/roar-rails) - include roar into rails
 


### PR DESCRIPTION
I used both. HTTParty is fine for really basic tasks. But Typhoeus is the one for serious job.

Typhoeus uses libcurl instead of net/http under the hood. It also supports parallel requests, mocking  and caching.

This is the future ;)
