### PR TITLE
Avoid rescuing StandardError and Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Follow the rules described in our [Git flow](GIT.md)
 ## [Rails](RAILS.md)
 
 ## Ruby
+* [avoid rescuing StandardError and Exception](http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby#answer-10048406)
 
 ## Projects in general
 


### PR DESCRIPTION
This includes postfix rescues like:

``` ruby
tree = Model.to_tree rescue []
```

Although they have clean syntax, they hide real errors and make debugging more difficult.

It's also noticeable that rescuing `Exception` [broadens the match](http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby#answer-10048406).
