### PR TITLE
Use attr_accessible instead of attr_protected

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -27,6 +27,7 @@ job_type :rake, "cd :path && RAILS_ENV=:environment /usr/local/bin/bundle exec r
   $('a').each(function(index, el) { carousel.add(index, el); });
   ```
 * Use I18n keys instead of plain text in views
+* Use attr_accessible instead of attr_protected
 
 ## Required gems for new apps
 


### PR DESCRIPTION
This is a well known best practice and in the light of security vulnerability in `attr_protected` discovered recently (https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/AFBKNY7VSH8) I think it is good to state this explititely in guidelines.
