### PR TITLE
Turn off helpers generation

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -29,12 +29,13 @@ job_type :rake, "cd :path && RAILS_ENV=:environment /usr/local/bin/bundle exec r
 * Use I18n keys instead of plain text in views
 * Use attr_accessible instead of attr_protected
 
-## Turn off assets generation
+## Setup generators
 ```ruby
 # config/application.rb
 config.generators do |g|
-  g.stylesheets = false
-  g.javascripts = false
+  g.helper      false
+  g.stylesheets false
+  g.javascripts false
 end
 ```
 


### PR DESCRIPTION
I don't use own helpers at all (I prefer cells over them), but even if I wish from my exp 99% of generated helper files are removed.
