### PR TITLE
Add schema_plus to required gems

### DIFF
--- a/rails-gems.md
+++ b/rails-gems.md
@@ -20,6 +20,10 @@ be treated as a "standard", please add it below.
 * [sidekiq](http://mperham.github.com/sidekiq/) - threaded background queue
 * [whenever](https://github.com/javan/whenever) - scheduler
 
+## DB
+
+* [schema_plus](https://github.com/lomba/schema_plus) - support for foreign keys, database defined validations and associations for postgresql
+
 ## Debug
 
 * [better_errors](https://github.com/charliesome/better_errors) - replace standard rails error page with more useful version

--- a/rails.md
+++ b/rails.md
@@ -59,12 +59,12 @@ end
 
 ## Required gems for new apps
 
-* [strong_parameters](https://github.com/rails/strong_parameters) (even for Rails 3.x)
-* [letter_opener](https://github.com/ryanb/letter_opener) (for development mode)
-* [slim](https://github.com/stonean/slim) and [slim-rails](https://github.com/leogalmeida/slim-rails)
-* [sidekiq](http://mperham.github.com/sidekiq/)
 * [devise-async](https://github.com/mhfs/devise-async)
-
+* [letter_opener](https://github.com/ryanb/letter_opener) (for development mode)
+* [schema_plus](https://github.com/lomba/schema_plus) - support for foreign keys, database defined validations and associations for postgresql
+* [sidekiq](http://mperham.github.com/sidekiq/)
+* [slim](https://github.com/stonean/slim) and [slim-rails](https://github.com/leogalmeida/slim-rails)
+* [strong_parameters](https://github.com/rails/strong_parameters) (even for Rails 3.x)
 
 ## Setup proper redis namespaces
 


### PR DESCRIPTION
W agreed to use [postgres](https://github.com/monterail/guidelines/blob/master/toolbox.md), we know that we need indexes #100.

So maybe we should add [schema_plus](https://github.com/lomba/schema_plus) by default?

I'm using it in one project, and I have no problems. It just works.

It automatically creates indexes for every foreign key and allows to create composite keys. Doc is full of examples how to use it, so it shouldn't bring any problems.
