### PR TITLE
Mark temporary css with TODO comment

### DIFF
--- a/stylesheets.md
+++ b/stylesheets.md
@@ -43,7 +43,7 @@ under `/styles` URL in development mode. It consists of rendered components with
 
 * **Embrace relative units.**
 
-* **Put temporary styles in `application.css` with proper comment**
+* **Put temporary styles in `temporary.css` with proper comment**
 
     ```css
     /* TODO - Tymon */
@@ -51,7 +51,6 @@ under `/styles` URL in development mode. It consists of rendered components with
     .some .other .crap { color: red }
     #pretty #awesome #border { border: 1px dashed purple; }
     ```
-
 
 If you’re not sure about those, read or watch:
 


### PR DESCRIPTION
Sometimes when developing backend stuff there is a need to write some css. We should put those ugly temporary css rules in one consistent place. I propose `application.css` (which shouldn't have any rules, only imports)

Example:

In `app/assets/stylesheets/application.css`

``` css

/* TODO - Tymon */
.some .temp .css #foo { width: 100px; } 
.some .other .crap { color: red }
#pretty #awesome #border { border: 1px dashed purple; }
```
