### PR TITLE
Never ever ever use natural keys in your database

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -58,6 +58,8 @@
 
 * Use `bin/setup` file as [thoughtbot describes](http://robots.thoughtbot.com/post/41439635905/bin-setup) (for example for git hooks).
 
+* Never ever ever use natural keys in your database.
+
 ## Setup generators
 
 ```ruby


### PR DESCRIPTION
This may sound obvious, but it just bit me. The case was about mongoid and automagically wrapping ids as ObjectId. More on this case here - https://gist.github.com/teamon/28cc33a4d3298f98596f

And if someone uses natural key:
![](http://25.media.tumblr.com/tumblr_m7xxdcwS921r74ytao1_1280.jpg)
