### PR TITLE
Do not use rails_config

### DIFF
--- a/gems.md
+++ b/gems.md
@@ -52,7 +52,6 @@ be treated as a "standard", please add it below.
 * [decent_exposure](https://github.com/voxdolo/decent_exposure) - helper for creating declarative interfaces in controllers
 * [figaro](https://github.com/laserlemon/figaro) - storing sensible settings in ENV
 * [friendly_id](https://github.com/norman/friendly_id) - slug generation
-* [rails_config](https://github.com/railsjedi/rails_config) - miscallanous settings for different stages
 
 ## Testing
 


### PR DESCRIPTION
[We are using it](https://github.com/monterail/guidelines/blob/master/gems.md#general) for a while and we know that it is very unstable (most of last versions doesn't work at all...). For sensitive config use `figaro` instead. I'm not sure what should we use for global settings and which could be commit into repo.

At least we can put such values into `application.yml.example` files.

/cc @chytreg @teamon @Ostrzy @szajbus @sheerun @jcieslar 
