### PR TITLE
Use new expectation syntax when using rspec

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -17,7 +17,7 @@
 * Use semantic versions for all gems in Gemfile before pushing to production.
 
 * Try to avoid calling self explicitly on reads
-  
+
   Prefer
 
   ```ruby
@@ -75,4 +75,12 @@ end
 def process_text(s)
   # ...
 end
+```
+
+## Testing
+
+* use a [new expectation syntax](http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax) when using RSpec (see [issue](https://github.com/monterail/guidelines/issues/170)):
+
+```ruby
+it { expect(something).to be_valid }
 ```


### PR DESCRIPTION
[Rspec has a new expectation syntax](http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax):

``` ruby
it { something.should be_valid }

# vs

it { expect(something).to be_valid }
```

... which is recommended by rspec devs. It simplifies monkey-patches in rspec and would be default option in rspec 3 (old syntax will be probably disabled).

You can read more on [rspec dev blog](http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3#what_about_the_old_expectationmock_syntax).
