### PR TITLE
Internal rule: do not hesitate to say "no opinion"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ According to [this issue](https://github.com/monterail/rules/issues/25) we agree
 * The idea is subscribed persons would be obligated to comment. We will mention them in such cases.
 * Final decision for merging is for CTO.
 * It's of course possible for non-declared person to participate. That list would help us determine if issue is ready to be accepted or it needs more discussion / time (for example if everyone would vote "no opinion").
+* If you have **no opinion** do not hesitate to tell that. At least you will leave a note that you read an issue.
 
 Here is current list of tags along their participants:
 


### PR DESCRIPTION
If you have no opinion - **say that**. Such a feedback is better than no feedback at all - when requester doesn't know if you need some time to express your thought about an issue, you don't care, you forgot about it or you just don't have an opinion.
