### PR TITLE
Use Node.js instead of therubyracer for execjs runtime

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -84,3 +84,5 @@ end
 ```ruby
 it { expect(something).to be_valid }
 ```
+
+* Use Node.js instead of therubyracer for execjs runtime


### PR DESCRIPTION
My reasons:
1. Therubyracer is unstable between platforms, platform versions, ruby interpreters and even ruby versons. I _personally_ couldn't install it on non-ree 1.8.7 and Windows (railsgirls), and had issues installing it on other combinations. Pretty much everytime there's native component compilation issue, it is therubyracer. I never had issues installing Node.js.
2. therubyracer is officially discouraged by heroku as it uses lot of memory. One the other hand node.js is very lightweight.
3. using therubyracer on server is just like installing node that can be used only by ruby apps (libv8)

btw. Node.js is necessary only on Windows and Ubuntu development, on Mac dev execjs is using JavaScriptCore. 
