### PR TITLE
Use "//" instead of "http://" wherever possible

### DIFF
--- a/html.md
+++ b/html.md
@@ -14,4 +14,6 @@
 
     Especially in Slim templates.
 
+* **Use `//` instead of `http://` for images, script or iframes. This will make life much easier if someday you decide to use https for site.
+
 If possible, document new markup proposals in our [styleguide](https://github.com/monterail/boilerplate-rails).


### PR DESCRIPTION
"//path" will be resolved by browser to "http://path" or "https://path" depending on current site protocol. Use is in cases like `<img src="//somehost.com/img.png"/>` or `<a href="//some-other-service.com">Link</a>`.

This will make life much easier if someday you decide to use https for site.
