### PR TITLE
Don’t use rgb(r, g, b) for colors; use rgba(#hex, alpha) instead rgba(r, g, b, alpha)

### DIFF
--- a/stylesheets.md
+++ b/stylesheets.md
@@ -12,7 +12,7 @@ under `/styles` URL in development mode. It consists of rendered components with
 * **Write stylesheets and html in accordance with [BEM](http://bem.info).**
 
   Our selectors:
-  
+
   ```
   .block {}
   .block__element {}
@@ -46,7 +46,7 @@ under `/styles` URL in development mode. It consists of rendered components with
 * **Try to add CSS properties instead of removing them.**
 
     If you need to remove styles that were applied too early, consider different scoping, usage of mixins or refactoring.
-    
+
 * **Never use data URI with properties that might be vendor-prefixed.**
 
     [The explanation](https://github.com/monterail/guidelines/issues/146).
@@ -67,6 +67,10 @@ under `/styles` URL in development mode. It consists of rendered components with
 * **Use `create`, `delete` and `update` for naming classes in CSS**
 
     Instead of `modified`, `removed`, `added` etc. It makes back-end guys’ life easier.
+
+* **When using Sass, take advantage of the `rgba(#hex, alpha)` format.
+
+    Apart from being shorter than `rgba(r, g, b, alpha)`, it’s a small step towards better code maintainability.
 
 ## Proper SCSS formatting
 


### PR DESCRIPTION
`rgb()` is as unreadable as `#hex` when it comes to color values, but the `#hex` values have better support in many graphic tools and are simply shorter to write. (I’d happily use `hsl()` and `hsla()`, but none of the apps I use acknowledges the format.)

To be consistent (and still write less code), use the Sass helper, `rgba(#hex, alpha)`, instead of the standard `rgba(r, g, b, alpha)` wherever possible for semi-transparent color values.
