### PR TITLE
If using gem from github put it under monterail organization

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -296,3 +296,16 @@ validates :domain, presence: true,
 
 Avoid switching from `DELETE` to `GET` for signout. It should be considered as a potential [security hole](http://homakov.blogspot.com/2012/04/csrf-afterparty-must-read-rules.html).
 
+## If using gem from github put it under monterail organization
+
+```ruby
+gem "ssl_routes", :github => "monterail/ssl_routes"
+```
+
+instead of
+
+```ruby
+gem "ssl_routes", :github => "sheerun/ssl_routes"
+```
+
+Bus factor++


### PR DESCRIPTION
``` ruby
gem "ssl_routes", :github => "monterail/ssl_routes"
```

instead of

``` ruby
gem "ssl_routes", :github => "sheerun/ssl_routes"
```

Bus factor++

/cc @jandudulski, @sheerun, @chytreg, @teamon, @szajbus, @Ostrzy, @jcieslar, @tallica
