### PR TITLE
Never ever switch from :delete to :get for logout action in devise

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -289,3 +289,8 @@ RESERVED_SUBDOMAINS = %w(
 validates :domain, presence: true,
                    subdomain: { reserved: RESERVED_SUBDOMAINS }
 ```
+
+## Devise
+
+Avoid switching from `DELETE` to `GET` for signout. It should be considered as a potential [security hole](http://homakov.blogspot.com/2012/04/csrf-afterparty-must-read-rules.html).
+


### PR DESCRIPTION
I know that using POST/DELETE for sign out action is kind of PITA but you don't want your users to be automagically signed out, do you?

Every action which changes the state of application should use CSRF token, including sign out. Homakov describes the problem on [his blogpost](http://homakov.blogspot.com/2012/04/csrf-afterparty-must-read-rules.html).

/cc @teamon @sheerun @Ostrzy @chytreg @jcieslar @szajbus 
