### PR TITLE
Single file extension

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -71,6 +71,8 @@
 
 * Add `db/schema.rb` to `.gitignore`
 
+* Use single file extension for default cases. Instead of `file.html.slim`, `file.css.sass`, `file.js.coffee` use `file.slim`, `file.sass`, `file.coffee`
+
 ## How to choose database
 
 * If you think about using mysql - use postgresql


### PR DESCRIPTION
Use single file extension for default cases. Instead of `file.html.slim`, `file.css.sass`, `file.js.coffee` use `file.slim`, `file.sass`, `file.coffee`. 

The default cases are:
- `slim` is equal to `html.slim`
- `sass|scss` is equal to `css.{sass|scss}`
- `coffee` is equal to `js.coffee`

Pros:
- It's shorter, defaults are well known, double extension is kind of pointless here

Cons:
- It somehow breaks consistency

@jandudulski, @sheerun, @chytreg, @szajbus, @Ostrzy, @jcieslar, @tallica, @porada, @venticco, @michlask
