### PR TITLE
Periodically run bundle update/bundle outdated

### DIFF
--- a/general.md
+++ b/general.md
@@ -11,3 +11,5 @@
   ```ruby
   every(1.day, at: ['00:00', '04:00', '08:00', ..., '20:00']) { Mailer.perform_async }
   ```
+
+* Add new gems in feature branches (or `next`). Perform big gem updates on `next` branch.


### PR DESCRIPTION
We should try to keep gems up to date as much as possible. I can see few possible ways to do that:
- Update gems in feature branch while working on it - possible lots of merge conflicts
- Update gems on master before release - please never do that
- Update gems on staging after merging feature branches - since staging branch is very temporary this will be pointless/have to be repeated a lot of times
- Treat gems update as a regular feature  (new branch, merged in staging etc) - there won't be task for that in trello, there won't be release date set up etc, this is very internal and most clients do not care\* about that.

Any ideas?

@jandudulski, @sheerun, @chytreg, @szajbus, @Ostrzy, @jcieslar, @tallica

*By "do not care" I mean "Do what you need to do" 
