### PR TITLE
Javascript naming

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -5,6 +5,7 @@
 * [Detect and inform about network issues](http://html5demos.com/offline-events#view-source), especially in SPA
 * Prefer $(this) over $(@) in CoffeeScript.
 * Try to avoid using [date.js](http://www.datejs.com/), use [moment.js](http://momentjs.com/) instead. datejs overwrites native methods and tends to break stuff.
+* Use `camelCase` for variable and function names. The only exception to this rule are JSON properties which are `under_scored`.
 
 ## JavaScript on Rails
 


### PR DESCRIPTION
How do you deal with the naming in CoffeeScript?
Do you use underscore as in Rails or camelCase as the Javascript prefer?

I tried to use in my latest Angular app to use JS convention and have some naming mismatch. Example

```
    $scope.accountGroups = []

    SharedWith.fetch().then (response) ->
      $scope.sharedWith = response.data
     # but in reponse data I get the Array and each object has account_group method :(
```

Maybe variable write using underscore convention but functions in camelcase

So I would have

```
$scope.my_nasty_var = 'Some secret text'

$scope.myAwesomeFunction = (no_camel_case) ->
  console.log 'Fuuuuuu'
```
